### PR TITLE
Add initial Jest and Playwright test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # 202506_LnH
 
+This project uses Jest for core unit tests and Playwright for UI integration tests.
+
+- `npx playwright install` - install browsers for UI tests
+## Scripts
+
+- `npm run test:core` - run unit tests
+- `npm run test:ui` - run integration tests
+- `npm test` - run both

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
     "jest": "^30.0.2",
     "playwright": "^1.53.1",
     "vite": "^6.3.5"
-  }
+  },
+  "type": "module"
 }

--- a/src/core/math.js
+++ b/src/core/math.js
@@ -1,0 +1,5 @@
+function add(a, b) {
+  return a + b;
+}
+
+module.exports = { add };

--- a/src/phaser/index.js
+++ b/src/phaser/index.js
@@ -1,0 +1,1 @@
+console.log('Game placeholder');

--- a/tests/ci/jest.config.js
+++ b/tests/ci/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/../core'],
+  transform: {},
+};

--- a/tests/ci/playwright.config.js
+++ b/tests/ci/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'playwright/test';
+
+export default defineConfig({
+  testDir: '../ui',
+  use: {
+    headless: true,
+  },
+});

--- a/tests/core/math.test.js
+++ b/tests/core/math.test.js
@@ -1,0 +1,5 @@
+const { add } = require('../../src/core/math.js');
+
+test('adds numbers', () => {
+  expect(add(2, 3)).toBe(5);
+});

--- a/tests/ui/index.spec.js
+++ b/tests/ui/index.spec.js
@@ -1,0 +1,12 @@
+import { test, expect } from 'playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fileUrl = 'file://' + path.resolve(__dirname, '../../index.html');
+
+test('has game container element', async ({ page }) => {
+  await page.goto(fileUrl);
+  await expect(page.locator('#game-container')).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary
- set up Jest for unit tests and Playwright for UI tests
- add a math helper as an example core module
- add sample unit and UI tests
- document test commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856da8ee400832c8815496de79b1c4c