### PR TITLE
Implement battle map scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
 <body>
     <div id="game-container"></div>
-    <script type="module" src="/src/phaser/index.js"></script>
+    <script type="module" src="./src/phaser/index.js"></script>
 </body>
 
 </html>

--- a/src/core/battle/battleCombat.js
+++ b/src/core/battle/battleCombat.js
@@ -1,0 +1,5 @@
+export function attack(attacker, defender) {
+  const damage = 1;
+  defender.hp = Math.max(0, defender.hp - damage);
+  return damage;
+}

--- a/src/core/battle/battleCore.js
+++ b/src/core/battle/battleCore.js
@@ -1,0 +1,17 @@
+import EventEmitter from '../shared/eventEmitter.js';
+import { Player, Rat } from './battleEntities.js';
+
+export default class BattleCore {
+  constructor() {
+    this.emitter = new EventEmitter();
+    this.player = new Player();
+    this.enemy = new Rat();
+  }
+
+  start() {
+    this.emitter.emit('battleStart', {
+      player: this.player,
+      enemy: this.enemy
+    });
+  }
+}

--- a/src/core/battle/battleEntities.js
+++ b/src/core/battle/battleEntities.js
@@ -1,0 +1,13 @@
+import Entity from '../shared/entities.js';
+
+export class Player extends Entity {
+  constructor(name = 'Hero', x = 0, y = 0) {
+    super(name, x, y, 20);
+  }
+}
+
+export class Rat extends Entity {
+  constructor(name = 'Rat', x = 5, y = 5) {
+    super(name, x, y, 5);
+  }
+}

--- a/src/core/battle/battleTimeQueue.js
+++ b/src/core/battle/battleTimeQueue.js
@@ -1,0 +1,5 @@
+export default class BattleTimeQueue {
+  constructor() {
+    this.queue = [];
+  }
+}

--- a/src/core/battle/battleTurnManager.js
+++ b/src/core/battle/battleTurnManager.js
@@ -1,0 +1,5 @@
+export default class BattleTurnManager {
+  constructor() {
+    this.queue = [];
+  }
+}

--- a/src/core/shared/entities.js
+++ b/src/core/shared/entities.js
@@ -1,0 +1,8 @@
+export default class Entity {
+  constructor(name, x = 0, y = 0, hp = 10) {
+    this.name = name;
+    this.x = x;
+    this.y = y;
+    this.hp = hp;
+  }
+}

--- a/src/core/shared/eventEmitter.js
+++ b/src/core/shared/eventEmitter.js
@@ -1,0 +1,21 @@
+export default class EventEmitter {
+  constructor() {
+    this.events = {};
+  }
+
+  on(event, listener) {
+    if (!this.events[event]) {
+      this.events[event] = [];
+    }
+    this.events[event].push(listener);
+  }
+
+  emit(event, payload) {
+    const listeners = this.events[event];
+    if (listeners) {
+      for (const fn of listeners) {
+        fn(payload);
+      }
+    }
+  }
+}

--- a/src/phaser/index.js
+++ b/src/phaser/index.js
@@ -1,1 +1,14 @@
-console.log('Game placeholder');
+import Phaser from 'phaser';
+import BattleScene from './scenes/battleScene.js';
+import WorldScene from './scenes/worldScene.js';
+import CityScene from './scenes/cityScene.js';
+
+const config = {
+  type: Phaser.AUTO,
+  width: 320,
+  height: 320,
+  parent: 'game-container',
+  scene: [BattleScene, WorldScene, CityScene]
+};
+
+new Phaser.Game(config);

--- a/src/phaser/scenes/battleScene.js
+++ b/src/phaser/scenes/battleScene.js
@@ -1,0 +1,28 @@
+import Phaser from 'phaser';
+import BattleCore from '../../core/battle/battleCore.js';
+
+export default class BattleScene extends Phaser.Scene {
+  constructor() {
+    super('battle');
+    this.core = new BattleCore();
+  }
+
+  create() {
+    const size = 32;
+    const gridSize = 10;
+    const graphics = this.add.graphics({ lineStyle: { width: 1, color: 0xffffff } });
+    for (let i = 0; i <= gridSize; i++) {
+      graphics.lineBetween(0, i * size, gridSize * size, i * size);
+      graphics.lineBetween(i * size, 0, i * size, gridSize * size);
+    }
+
+    // simple player and enemy as rectangles
+    this.playerRect = this.add.rectangle(size / 2, size / 2, size - 4, size - 4, 0x00ff00);
+    this.enemyRect = this.add.rectangle(5 * size + size / 2, 5 * size + size / 2, size - 4, size - 4, 0xff0000);
+
+    this.core.emitter.on('battleStart', ({ player, enemy }) => {
+      console.log('Battle started', player, enemy);
+    });
+    this.core.start();
+  }
+}

--- a/src/phaser/scenes/cityScene.js
+++ b/src/phaser/scenes/cityScene.js
@@ -1,0 +1,9 @@
+import Phaser from 'phaser';
+export default class CityScene extends Phaser.Scene {
+  constructor() {
+    super('city');
+  }
+  create() {
+    this.add.text(10, 10, 'City Scene');
+  }
+}

--- a/src/phaser/scenes/worldScene.js
+++ b/src/phaser/scenes/worldScene.js
@@ -1,0 +1,9 @@
+import Phaser from 'phaser';
+export default class WorldScene extends Phaser.Scene {
+  constructor() {
+    super('world');
+  }
+  create() {
+    this.add.text(10, 10, 'World Scene');
+  }
+}


### PR DESCRIPTION
## Summary
- implement minimal battle core with entities and event emitter
- create Phaser scenes and register them
- render a simple battle grid when the game starts
- adjust index.html to use relative path for module loading

## Testing
- `npm run test:core`
- `npm run test:ui`


------
https://chatgpt.com/codex/tasks/task_e_6856dde16ab8832cbfa6b58c6ec4ad6c