### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -160,6 +160,9 @@ UI modules import only their core’s events and APIs.
 - CI pipelines in `/tests/ci` run all suites and enforce coverage. Before running Playwright tests locally or in CI, install the browsers with `npx playwright install`.
 
 ---
+## Build & Deployment
+- Bundled with Vite. The `vite.config.js` sets `base: '/202506_LnH/'` so assets resolve correctly on GitHub Pages.
+- Run `npm run deploy` to build and publish the `dist` directory using `gh-pages`.
 
 ## Extensibility & Next Steps
 - Add new map cores (e.g., dungeon crawler, naval travel).

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import path from 'path';
 
 export default defineConfig({
+    base: '/202506_LnH/',
     resolve: {
         alias: {
             '@core': path.resolve(__dirname, 'src/core'),


### PR DESCRIPTION
## Summary
- set `base` in Vite config so assets load on GitHub Pages
- document build & deployment process in design notes

## Testing
- `npm run test:core`
- `npx playwright install` *(to install browsers for UI tests)*
- `npm run test:ui`


------
https://chatgpt.com/codex/tasks/task_e_6856e6b49e0c832c983039af5557fbd1