### PR TITLE
Add movement buttons

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -137,7 +137,7 @@ Shared code (entities, events) lives in `/src/core/shared` and is imported by ea
 ---
 
 ## UI Components
-- **Battle UI** (`/ui/battle`): health bar, action menu, turn log.
+ - **Battle UI** (`/ui/battle`): health bar, action menu, turn log, directional move buttons.
 - **World UI** (`/ui/world`): worldHUD, travelMenu.
 - **City UI** (`/ui/city`): tradeInterface, dialogueBox.
 

--- a/src/phaser/scenes/battleScene.js
+++ b/src/phaser/scenes/battleScene.js
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import BattleCore from '../../core/battle/battleCore.js';
+import createDirectionButtons from '../ui/battle/directionButtons.js';
 
 export default class BattleScene extends Phaser.Scene {
   constructor() {
@@ -24,5 +25,15 @@ export default class BattleScene extends Phaser.Scene {
       console.log('Battle started', player, enemy);
     });
     this.core.start();
+
+    const onMove = (dx, dy) => {
+      const newX = Phaser.Math.Clamp(this.core.player.x + dx, 0, gridSize - 1);
+      const newY = Phaser.Math.Clamp(this.core.player.y + dy, 0, gridSize - 1);
+      this.core.player.x = newX;
+      this.core.player.y = newY;
+      this.playerRect.setPosition(newX * size + size / 2, newY * size + size / 2);
+    };
+
+    this.directionUI = createDirectionButtons(this, onMove);
   }
 }

--- a/src/phaser/ui/battle/directionButtons.js
+++ b/src/phaser/ui/battle/directionButtons.js
@@ -1,0 +1,43 @@
+export default function createDirectionButtons(scene, onMove) {
+  const container = document.createElement('div');
+  container.id = 'direction-buttons';
+  Object.assign(container.style, {
+    position: 'absolute',
+    bottom: '10px',
+    left: '10px',
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 40px)',
+    gridTemplateRows: 'repeat(3, 40px)',
+    gap: '2px',
+  });
+
+  const directions = [
+    { label: '↖', dx: -1, dy: -1 },
+    { label: '↑', dx: 0, dy: -1 },
+    { label: '↗', dx: 1, dy: -1 },
+    { label: '←', dx: -1, dy: 0 },
+    null,
+    { label: '→', dx: 1, dy: 0 },
+    { label: '↙', dx: -1, dy: 1 },
+    { label: '↓', dx: 0, dy: 1 },
+    { label: '↘', dx: 1, dy: 1 },
+  ];
+
+  directions.forEach((dir) => {
+    if (!dir) {
+      const spacer = document.createElement('span');
+      container.appendChild(spacer);
+      return;
+    }
+    const btn = document.createElement('button');
+    btn.textContent = dir.label;
+    btn.addEventListener('click', () => onMove(dir.dx, dir.dy));
+    container.appendChild(btn);
+  });
+
+  scene.game.canvas.parentNode.appendChild(container);
+
+  return {
+    destroy: () => container.remove(),
+  };
+}


### PR DESCRIPTION
## Summary
- add a `directionButtons` UI helper
- integrate buttons in `battleScene`
- document directional move buttons in the design doc

## Testing
- `npm run test:core`
- `npm run test:ui`

------
https://chatgpt.com/codex/tasks/task_e_6856f3c23ab4832c85b28394d0561681