### PR TITLE
Update battle start positions

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -99,6 +99,7 @@ Shared code (entities, events) lives in `/src/core/shared` and is imported by ea
 ### Battle Core
 - **battleCore.js**: Manages turn loop, action queue, and event emission.
 - **battleEntities.js**: Player and Rat classes extend shared `Entity`.
+- **Default Positions**: Player starts at `(0,4)` and Rat at `(9,4)` on the battle grid.
 - **battleCombat.js**: Damage, hit/miss, and status logic.
 - **battleTurnManager.js** & **battleTimeQueue.js**: Schedule and dequeue actions by cost.
 

--- a/src/core/battle/battleEntities.js
+++ b/src/core/battle/battleEntities.js
@@ -1,13 +1,13 @@
 import Entity from '../shared/entities.js';
 
 export class Player extends Entity {
-  constructor(name = 'Hero', x = 0, y = 0) {
+  constructor(name = 'Hero', x = 0, y = 4) {
     super(name, x, y, 20);
   }
 }
 
 export class Rat extends Entity {
-  constructor(name = 'Rat', x = 5, y = 5) {
+  constructor(name = 'Rat', x = 9, y = 4) {
     super(name, x, y, 5);
   }
 }

--- a/src/phaser/scenes/battleScene.js
+++ b/src/phaser/scenes/battleScene.js
@@ -17,8 +17,8 @@ export default class BattleScene extends Phaser.Scene {
     }
 
     // simple player and enemy as rectangles
-    this.playerRect = this.add.rectangle(size / 2, size / 2, size - 4, size - 4, 0x00ff00);
-    this.enemyRect = this.add.rectangle(5 * size + size / 2, 5 * size + size / 2, size - 4, size - 4, 0xff0000);
+    this.playerRect = this.add.rectangle(size / 2, 4 * size + size / 2, size - 4, size - 4, 0x00ff00);
+    this.enemyRect = this.add.rectangle(9 * size + size / 2, 4 * size + size / 2, size - 4, size - 4, 0xff0000);
 
     this.core.emitter.on('battleStart', ({ player, enemy }) => {
       console.log('Battle started', player, enemy);


### PR DESCRIPTION
## Summary
- set Player start location to (0,4)
- set Rat start location to (9,4)
- update battleScene to match new positions
- document default battle positions

## Testing
- `npm run test:core`
- `npx playwright install`
- `npm run test:ui`


------
https://chatgpt.com/codex/tasks/task_e_6856f3ebd490832c9ec03834f51f6ef9