### PR TITLE
Add player HP/MP display

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -115,7 +115,7 @@ Shared code (entities, events) lives in `/src/core/shared` and is imported by ea
 ---
 
 ## Shared Systems
-- **entities.js**: Base `Entity` with position, stats, actions list.
+- **entities.js**: Base `Entity` with position, `hp`, and `mp` stats.
 - **eventEmitter.js**: Simple pub/sub for events across core and UI.
 
 ---
@@ -137,7 +137,7 @@ Shared code (entities, events) lives in `/src/core/shared` and is imported by ea
 ---
 
 ## UI Components
-- **Battle UI** (`/ui/battle`): health bar, action menu, turn log.
+- **Battle UI** (`/ui/battle`): health bar, action menu, turn log, player stats display.
 - **World UI** (`/ui/world`): worldHUD, travelMenu.
 - **City UI** (`/ui/city`): tradeInterface, dialogueBox.
 

--- a/src/core/battle/battleEntities.js
+++ b/src/core/battle/battleEntities.js
@@ -2,12 +2,12 @@ import Entity from '../shared/entities.js';
 
 export class Player extends Entity {
   constructor(name = 'Hero', x = 0, y = 0) {
-    super(name, x, y, 20);
+    super(name, x, y, 20, 10);
   }
 }
 
 export class Rat extends Entity {
   constructor(name = 'Rat', x = 5, y = 5) {
-    super(name, x, y, 5);
+    super(name, x, y, 5, 0);
   }
 }

--- a/src/core/shared/entities.js
+++ b/src/core/shared/entities.js
@@ -1,8 +1,9 @@
 export default class Entity {
-  constructor(name, x = 0, y = 0, hp = 10) {
+  constructor(name, x = 0, y = 0, hp = 10, mp = 0) {
     this.name = name;
     this.x = x;
     this.y = y;
     this.hp = hp;
+    this.mp = mp;
   }
 }

--- a/src/phaser/scenes/battleScene.js
+++ b/src/phaser/scenes/battleScene.js
@@ -20,8 +20,13 @@ export default class BattleScene extends Phaser.Scene {
     this.playerRect = this.add.rectangle(size / 2, size / 2, size - 4, size - 4, 0x00ff00);
     this.enemyRect = this.add.rectangle(5 * size + size / 2, 5 * size + size / 2, size - 4, size - 4, 0xff0000);
 
+    this.hpText = this.add.text(10, 300, '');
+    this.mpText = this.add.text(80, 300, '');
+
     this.core.emitter.on('battleStart', ({ player, enemy }) => {
       console.log('Battle started', player, enemy);
+      this.hpText.setText(`HP: ${player.hp}`);
+      this.mpText.setText(`MP: ${player.mp}`);
     });
     this.core.start();
   }


### PR DESCRIPTION
## Summary
- show player's HP and MP on the battle screen
- track mp stat on all entities
- document hp/mp stats in design spec

## Testing
- `npm run test:core`
- `npm run test:ui`


------
https://chatgpt.com/codex/tasks/task_e_6856f47ab770832c8e6c5aa3072668e3