### PR TITLE
Add battle turn log and movement events

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -139,6 +139,8 @@ Shared code (entities, events) lives in `/src/core/shared` and is imported by ea
 
 ## UI Components
  - **Battle UI** (`/ui/battle`): health bar, action menu, turn log, directional move buttons.
+   - The turn log is a DOM element (`#turn-log`) created by `battleScene`.
+     It displays messages when the battle starts and whenever the player moves.
 - **World UI** (`/ui/world`): worldHUD, travelMenu.
 - **City UI** (`/ui/city`): tradeInterface, dialogueBox.
 

--- a/src/core/battle/battleCore.js
+++ b/src/core/battle/battleCore.js
@@ -6,6 +6,7 @@ export default class BattleCore {
     this.emitter = new EventEmitter();
     this.player = new Player();
     this.enemy = new Rat();
+    this.gridSize = 10;
   }
 
   start() {
@@ -13,5 +14,13 @@ export default class BattleCore {
       player: this.player,
       enemy: this.enemy
     });
+  }
+
+  movePlayer(dx, dy) {
+    const newX = Math.max(0, Math.min(this.player.x + dx, this.gridSize - 1));
+    const newY = Math.max(0, Math.min(this.player.y + dy, this.gridSize - 1));
+    this.player.x = newX;
+    this.player.y = newY;
+    this.emitter.emit('playerMove', { x: newX, y: newY });
   }
 }

--- a/src/phaser/scenes/battleScene.js
+++ b/src/phaser/scenes/battleScene.js
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import BattleCore from '../../core/battle/battleCore.js';
 import createDirectionButtons from '../ui/battle/directionButtons.js';
+import createTurnLog from '../ui/battle/turnLog.js';
 
 export default class BattleScene extends Phaser.Scene {
   constructor() {
@@ -21,19 +22,19 @@ export default class BattleScene extends Phaser.Scene {
     this.playerRect = this.add.rectangle(size / 2, 4 * size + size / 2, size - 4, size - 4, 0x00ff00);
     this.enemyRect = this.add.rectangle(9 * size + size / 2, 4 * size + size / 2, size - 4, size - 4, 0xff0000);
 
-    this.core.emitter.on('battleStart', ({ player, enemy }) => {
-      console.log('Battle started', player, enemy);
+    this.turnLog = createTurnLog(this);
+
+    this.core.emitter.on('battleStart', () => {
+      this.turnLog.addMessage('Battle started');
     });
+
+    this.core.emitter.on('playerMove', ({ x, y }) => {
+      this.playerRect.setPosition(x * size + size / 2, y * size + size / 2);
+      this.turnLog.addMessage(`Player moved to (${x}, ${y})`);
+    });
+
     this.core.start();
 
-    const onMove = (dx, dy) => {
-      const newX = Phaser.Math.Clamp(this.core.player.x + dx, 0, gridSize - 1);
-      const newY = Phaser.Math.Clamp(this.core.player.y + dy, 0, gridSize - 1);
-      this.core.player.x = newX;
-      this.core.player.y = newY;
-      this.playerRect.setPosition(newX * size + size / 2, newY * size + size / 2);
-    };
-
-    this.directionUI = createDirectionButtons(this, onMove);
+    this.directionUI = createDirectionButtons(this, (dx, dy) => this.core.movePlayer(dx, dy));
   }
 }

--- a/src/phaser/ui/battle/turnLog.js
+++ b/src/phaser/ui/battle/turnLog.js
@@ -1,0 +1,28 @@
+export default function createTurnLog(scene) {
+  const container = document.createElement('div');
+  container.id = 'turn-log';
+  Object.assign(container.style, {
+    position: 'absolute',
+    top: '10px',
+    right: '10px',
+    width: '150px',
+    height: '80px',
+    overflowY: 'auto',
+    background: 'rgba(0, 0, 0, 0.5)',
+    color: '#fff',
+    fontFamily: 'monospace',
+    fontSize: '12px',
+    padding: '4px'
+  });
+
+  scene.game.canvas.parentNode.appendChild(container);
+
+  function addMessage(text) {
+    const line = document.createElement('div');
+    line.textContent = text;
+    container.appendChild(line);
+    container.scrollTop = container.scrollHeight;
+  }
+
+  return { addMessage, destroy: () => container.remove() };
+}

--- a/tests/ui/turnLog.spec.js
+++ b/tests/ui/turnLog.spec.js
@@ -1,0 +1,18 @@
+import { test, expect } from 'playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fileUrl = 'file://' + path.resolve(__dirname, '../../index.html');
+
+test('log element updates after move', async ({ page }) => {
+  await page.goto(fileUrl);
+  const log = page.locator('#turn-log');
+  await expect(log).toHaveCount(1);
+  await expect(log).toContainText('Battle started');
+
+  const firstBtn = page.locator('#direction-buttons button').first();
+  await firstBtn.click();
+  await expect(log).toContainText('Player moved');
+});


### PR DESCRIPTION
## Summary
- implement BattleCore.movePlayer and emit `playerMove`
- display a turn log in BattleScene and log player moves
- expose new UI helper to create the log element
- add integration test to verify turn log exists and updates
- document battle log behaviour

## Testing
- `npm run test:core`
- `npm run test:ui` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856f6e3fd6c832ca9bfeb310e4af536